### PR TITLE
Add prompt templates to Structured Response Endpoints

### DIFF
--- a/src/api/structuredresponseendpoint/createSRE.ts
+++ b/src/api/structuredresponseendpoint/createSRE.ts
@@ -7,6 +7,7 @@ interface CreateSREPayload {
     description?: string;
     pd_id: string;
     is_public?: boolean;
+    prompt_template?: string;
 }
 
 export async function createSRE(payload: CreateSREPayload): Promise<StructuredResponseEndpoint> {

--- a/src/api/structuredresponseendpoint/runSRE.ts
+++ b/src/api/structuredresponseendpoint/runSRE.ts
@@ -6,6 +6,7 @@ import { AnyType } from "@/types/tools";
 export interface RunSREPayload {
     sre_id: string;
     prompt: string;
+    prompt_args?: Record<string, string>;
 }
 
 export async function runSRE(payload: RunSREPayload): Promise<AnyType> {

--- a/src/api/structuredresponseendpoint/runSRE.ts
+++ b/src/api/structuredresponseendpoint/runSRE.ts
@@ -2,10 +2,8 @@ import { authStore } from "@/store/AuthStore";
 import { checkResponseAndGetJson } from "@/utils/api/checkResponseAndParseJson";
 import { AnyType } from "@/types/tools";
 
-
 export interface RunSREPayload {
     sre_id: string;
-    prompt: string;
     prompt_args?: Record<string, string>;
 }
 
@@ -17,7 +15,7 @@ export async function runSRE(payload: RunSREPayload): Promise<AnyType> {
             'Authorization': await authStore.getAccessToken() || '',
             'Content-Type': 'application/json'
         },
-        body: JSON.stringify(payload)
+        body: JSON.stringify(payload.prompt_args || {})
     });
     return await checkResponseAndGetJson(response) as unknown as AnyType;
   } catch (error) {

--- a/src/api/structuredresponseendpoint/updateSRE.ts
+++ b/src/api/structuredresponseendpoint/updateSRE.ts
@@ -7,6 +7,7 @@ interface UpdateSREPayload {
     name?: string;
     description?: string;
     is_public?: boolean;
+    prompt_template?: string;
 }
 
 export async function updateSRE(payload: UpdateSREPayload): Promise<StructuredResponseEndpoint> {

--- a/src/app/(authenticated)/sre-builder/[[...sre_id]]/page.tsx
+++ b/src/app/(authenticated)/sre-builder/[[...sre_id]]/page.tsx
@@ -248,6 +248,21 @@ const SREBuilderPage = observer(({ params }: SREBuilderPageProps) => {
           />
         </FormControl>
 
+        {sreBuilderStore.templateArgs.length > 0 && (
+          <Flex direction="column" gap={4} mt={4} w="100%">
+            {sreBuilderStore.templateArgs.map((arg, idx) => (
+              <FormControl key={idx}>
+                <FormLabel>{arg}</FormLabel>
+                <Input
+                  placeholder="Value"
+                  value={sreBuilderStore.templateArgsInput[arg] ?? ''}
+                  onChange={(e) => sreBuilderStore.updateTemplateArg(arg, e.target.value)}
+                />
+              </FormControl>
+            ))}
+          </Flex>
+        )}
+
         <Button
           onClick={onRunSRE}
           variant={"outline"}

--- a/src/app/(authenticated)/sre-builder/[[...sre_id]]/page.tsx
+++ b/src/app/(authenticated)/sre-builder/[[...sre_id]]/page.tsx
@@ -5,7 +5,7 @@ import { useNavigationGuard } from "next-navigation-guard";
 import {
   Flex, FormControl, Heading, IconButton, Input, Button, Tooltip, Textarea, Box, Switch,
   Modal, ModalBody, ModalCloseButton, ModalContent, ModalHeader, ModalOverlay,
-  useColorMode
+  useColorMode, Text
 } from "@chakra-ui/react";
 import { ArrowBackIcon } from "@chakra-ui/icons";
 import { FormLabelToolTip } from "@/app/components/FormLableToolTip";
@@ -172,6 +172,30 @@ const SREBuilderPage = observer(({ params }: SREBuilderPageProps) => {
             onChange={(e) => sreBuilderStore.setDescription(e.target.value)}
           />
         </FormControl>
+
+        {/* Prompt Template */}
+        <FormControl>
+          <FormLabelToolTip
+            label="Prompt Template"
+            tooltip="Template used when calling this endpoint. Variables should be wrapped in curly braces."
+          />
+          <Textarea
+            mt={2}
+            placeholder="Extract order details from the following text: {message}"
+            value={sreBuilderStore.sre.prompt_template}
+            onChange={(e) => sreBuilderStore.setPromptTemplate(e.target.value)}
+            rows={5}
+          />
+        </FormControl>
+
+        {sreBuilderStore.templateArgs.length > 0 && (
+          <Flex direction="column" w="100%" mt={2} gap={2}>
+            <Heading size="sm">Template Args</Heading>
+            {sreBuilderStore.templateArgs.map((arg, idx) => (
+              <Text key={idx}>- {arg}</Text>
+            ))}
+          </Flex>
+        )}
 
         {/* SRE Is Public */}
         <FormControl>

--- a/src/app/(authenticated)/sre-builder/[[...sre_id]]/page.tsx
+++ b/src/app/(authenticated)/sre-builder/[[...sre_id]]/page.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef } from "react";
 import { useNavigationGuard } from "next-navigation-guard";
 import {
   Flex, FormControl, Heading, IconButton, Input, Button, Tooltip, Textarea, Box, Switch,
   Modal, ModalBody, ModalCloseButton, ModalContent, ModalHeader, ModalOverlay,
-  useColorMode, Text
+  useColorMode, Text,
+  FormLabel
 } from "@chakra-ui/react";
 import { ArrowBackIcon } from "@chakra-ui/icons";
 import { FormLabelToolTip } from "@/app/components/FormLableToolTip";
@@ -29,7 +30,6 @@ const SREBuilderPage = observer(({ params }: SREBuilderPageProps) => {
   const isShowingNavAlert = useRef(false);
 
   const { showAlert } = useAlert();
-  const [prompt, setPrompt] = useState("");
   const resultBackgroundColor = useColorMode().colorMode === 'dark' ? "#2b2b2b" : "#f7f7f7";
 
   useEffect(() => {
@@ -125,7 +125,7 @@ const SREBuilderPage = observer(({ params }: SREBuilderPageProps) => {
   const onRunSRE = async () => {
     const success = await sreBuilderStore.saveSRE();
     if (!success) return;
-    await sreBuilderStore.runSRE(prompt);
+    await sreBuilderStore.runSRE();
   };
 
 
@@ -235,18 +235,6 @@ const SREBuilderPage = observer(({ params }: SREBuilderPageProps) => {
 
         {/* Run SRE Test */}
         <Heading size="md">Test Structured Response Endpoint</Heading>
-        <FormControl>
-          <FormLabelToolTip
-            label="Prompt"
-            tooltip="Paste a prompt here to test what the SRE extracts."
-          />
-          <Textarea
-            value={prompt}
-            onChange={(e) => setPrompt(e.target.value)}
-            placeholder="Hi, my name is John Doe and I ordered a laptop yesterday..."
-            rows={5}
-          />
-        </FormControl>
 
         {sreBuilderStore.templateArgs.length > 0 && (
           <Flex direction="column" gap={4} mt={4} w="100%">

--- a/src/store/StructuredResponseEndpointBuilderStore.ts
+++ b/src/store/StructuredResponseEndpointBuilderStore.ts
@@ -1,4 +1,4 @@
-import { makeAutoObservable } from "mobx";
+import { makeAutoObservable, computed } from "mobx";
 import { ShowAlertParams } from "@/app/components/AlertProvider";
 import { authStore } from "./AuthStore";
 import { Parameter } from "@/types/parameterdefinition";
@@ -20,6 +20,7 @@ const defaultSRE: StructuredResponseEndpoint = {
     name: '',
     description: '',
     pd_id: '',
+    prompt_template: '',
     is_public: false,
     created_at: 0,
     updated_at: 0,
@@ -50,9 +51,15 @@ class StructuredResponseEndpointBuilderStore {
     runResult: AnyType | undefined = undefined;
     hasUpdatedSRE = false;
     hasUpdatedParameterDefinition = false;
+    get templateArgs(): string[] {
+        const matches = this.sre.prompt_template?.match(/\{([^}]+)\}/g) || [];
+        return matches.map((m) => m.replace(/[{}]/g, ""));
+    }
 
     constructor() {
-        makeAutoObservable(this);
+        makeAutoObservable(this, {
+            templateArgs: computed,
+        });
     }
 
     reset = () => {
@@ -137,6 +144,11 @@ class StructuredResponseEndpointBuilderStore {
 
     setDescription = (description: string) => {
         this.sre.description = description;
+        this.hasUpdatedSRE = true;
+    }
+
+    setPromptTemplate = (template: string) => {
+        this.sre.prompt_template = template;
         this.hasUpdatedSRE = true;
     }
 

--- a/src/store/StructuredResponseEndpointBuilderStore.ts
+++ b/src/store/StructuredResponseEndpointBuilderStore.ts
@@ -341,12 +341,11 @@ class StructuredResponseEndpointBuilderStore {
 
     // RUNNING
 
-    runSRE = async (prompt: string): Promise<void> => {
+    runSRE = async (): Promise<void> => {
         try {
             this.isRunningSRE = true;
             const result = await runSRE({
                 sre_id: this.sre.sre_id,
-                prompt,
                 prompt_args: this.templateArgsInput,
             });
             this.runResult = result;

--- a/src/types/structuredresponseendpoint.ts
+++ b/src/types/structuredresponseendpoint.ts
@@ -4,6 +4,11 @@ export interface StructuredResponseEndpoint {
     name: string;
     description?: string;
     pd_id: string;
+    /**
+     * Prompt template used when generating the structured response.
+     * Supports variables wrapped in curly braces e.g. {variable}.
+     */
+    prompt_template?: string;
     is_public: boolean;
     created_at: number;
     updated_at: number;


### PR DESCRIPTION
## Summary
- add prompt templates to structured endpoint types
- compute template args from the prompt template
- remove the uses_prompt_template_args toggle and related state
- show computed template args when editing the endpoint

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68466e8c269c83279d88e4255f65c13b