### PR TITLE
Add JSON document CRUD UI

### DIFF
--- a/src/api/jsondocument/createJsonDocument.ts
+++ b/src/api/jsondocument/createJsonDocument.ts
@@ -1,0 +1,25 @@
+import { JsonDocument } from "@/types/jsondocument";
+import { authStore } from "@/store/AuthStore";
+import { checkResponseAndGetJson } from "@/utils/api/checkResponseAndParseJson";
+
+interface CreateJsonDocumentPayload {
+    name: string;
+    data: Record<string, unknown>;
+}
+
+export async function createJsonDocument(payload: CreateJsonDocumentPayload): Promise<JsonDocument> {
+    try {
+        const response = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/json-document`, {
+            method: 'POST',
+            headers: {
+                'Authorization': await authStore.getAccessToken() || '',
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(payload),
+        });
+        return await checkResponseAndGetJson(response) as unknown as JsonDocument;
+    } catch (error) {
+        const errorMessage = (error as Error).message || 'An unknown error occurred creating the document';
+        throw Error(errorMessage);
+    }
+}

--- a/src/api/jsondocument/deleteJsonDocument.ts
+++ b/src/api/jsondocument/deleteJsonDocument.ts
@@ -1,0 +1,18 @@
+import { authStore } from "@/store/AuthStore";
+import { checkResponseAndGetJson } from "@/utils/api/checkResponseAndParseJson";
+
+export async function deleteJsonDocument(documentId: string): Promise<void> {
+    try {
+        const response = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/json-document/${documentId}`, {
+            method: 'DELETE',
+            headers: {
+                'Authorization': await authStore.getAccessToken() || '',
+                'Content-Type': 'application/json'
+            }
+        });
+        await checkResponseAndGetJson(response);
+    } catch (error) {
+        const errorMessage = (error as Error).message || 'An unknown error occurred deleting the document';
+        throw Error(errorMessage);
+    }
+}

--- a/src/api/jsondocument/getJsonDocuments.ts
+++ b/src/api/jsondocument/getJsonDocuments.ts
@@ -1,0 +1,19 @@
+import { JsonDocument } from "@/types/jsondocument";
+import { authStore } from "@/store/AuthStore";
+import { checkResponseAndGetJson } from "@/utils/api/checkResponseAndParseJson";
+
+export async function getJsonDocuments(): Promise<JsonDocument[]> {
+    try {
+        const response = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/json-documents`, {
+            headers: {
+                'Authorization': await authStore.getAccessToken() || '',
+                'Content-Type': 'application/json'
+            },
+        });
+        const obj = await checkResponseAndGetJson(response);
+        return obj["documents"] as JsonDocument[];
+    } catch (error) {
+        const errorMessage = (error as Error).message || 'An unknown error occurred getting the documents';
+        throw Error(errorMessage);
+    }
+}

--- a/src/api/jsondocument/updateJsonDocument.ts
+++ b/src/api/jsondocument/updateJsonDocument.ts
@@ -1,0 +1,26 @@
+import { JsonDocument } from "@/types/jsondocument";
+import { authStore } from "@/store/AuthStore";
+import { checkResponseAndGetJson } from "@/utils/api/checkResponseAndParseJson";
+
+interface UpdateJsonDocumentPayload {
+    document_id: string;
+    name: string;
+    data: Record<string, unknown>;
+}
+
+export async function updateJsonDocument(payload: UpdateJsonDocumentPayload): Promise<JsonDocument> {
+    try {
+        const response = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/json-document/${payload.document_id}`, {
+            method: 'POST',
+            headers: {
+                'Authorization': await authStore.getAccessToken() || '',
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(payload),
+        });
+        return await checkResponseAndGetJson(response) as unknown as JsonDocument;
+    } catch (error) {
+        const errorMessage = (error as Error).message || 'An unknown error occurred updating the document';
+        throw Error(errorMessage);
+    }
+}

--- a/src/app/(authenticated)/components/Sidebar.tsx
+++ b/src/app/(authenticated)/components/Sidebar.tsx
@@ -22,7 +22,7 @@ import { RiRobot3Fill } from "react-icons/ri";
 import { MdChatBubble } from "react-icons/md";
 import { BiDotsVerticalRounded } from 'react-icons/bi';
 import { MdOutlineWebAsset } from "react-icons/md";
-import { FiTool } from "react-icons/fi";
+import { FiTool, FiFileText } from "react-icons/fi";
 import { VscJson } from "react-icons/vsc";
 import { ChevronDownIcon, ChevronUpIcon } from '@chakra-ui/icons';
 import { useRouter } from 'next/navigation';
@@ -46,6 +46,7 @@ const Sidebar = observer(({ isMobile, isOpen, onClose }: SidebarProps) => {
     const tabs = [
         { icon: RiRobot3Fill, title: 'Agents', route: '/agents' },
         { icon: FiTool, title: 'Agent Tools', route: '/tools' },
+        { icon: FiFileText, title: 'Documents', route: '/documents' },
         { icon: VscJson, title: 'Structured Responses', route: '/sres' },
         { icon: MdChatBubble, title: 'Chat', route: '/chat' },
         { icon: MdOutlineWebAsset, title: 'Chat Pages', route: '/chat-pages' },

--- a/src/app/(authenticated)/documents/page.tsx
+++ b/src/app/(authenticated)/documents/page.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import React, { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { observer } from 'mobx-react-lite';
+import { jsonDocumentsStore } from '@/store/JsonDocumentsStore';
+import { jsonDocumentBuilderStore } from '@/store/JsonDocumentBuilderStore';
+import { JsonDocument } from '@/types/jsondocument';
+import {
+  Box,
+  Heading,
+  Grid,
+  GridItem,
+  Flex,
+  Text,
+  Spinner,
+} from '@chakra-ui/react';
+import Card from '@/app/components/Card';
+import { useAlert } from '@/app/components/AlertProvider';
+import { authStore } from '@/store/AuthStore';
+
+const DocumentsPage = observer(() => {
+  const router = useRouter();
+  const { showAlert } = useAlert();
+
+  useEffect(() => {
+    if (!authStore.signedIn) return;
+    jsonDocumentsStore.setShowAlert(showAlert);
+    jsonDocumentsStore.loadDocuments();
+  });
+
+  const handleAddDocumentClick = () => {
+    jsonDocumentBuilderStore.reset();
+    jsonDocumentBuilderStore.setIsNewDocument(true);
+    router.push('/json-document-builder');
+  };
+
+  const handleDocumentClick = (doc: JsonDocument) => {
+    jsonDocumentBuilderStore.setDocument({ ...doc });
+    router.push(`/json-document-builder/${doc.document_id}`);
+  };
+
+  return (
+    <Box p={6}>
+      <Heading as="h1" size="xl" mb={6}>
+        Documents
+      </Heading>
+      {jsonDocumentsStore.documentsLoading ? (
+        <Flex justify="center" align="center" height="200px">
+          <Spinner size="xl" />
+        </Flex>
+      ) : (
+        <Box>
+          <Grid templateColumns="repeat(auto-fill, minmax(200px, 1fr))" gap={6}>
+            <GridItem>
+              <Flex
+                align="center"
+                justify="center"
+                bg="gray.100"
+                _dark={{ bg: 'gray.700', borderColor: 'gray.600' }}
+                p={6}
+                borderRadius="md"
+                border="1px dashed"
+                borderColor="gray.300"
+                cursor="pointer"
+                _hover={{ bg: 'gray.200', _dark: { bg: 'gray.600' } }}
+                onClick={handleAddDocumentClick}
+                minHeight="150px"
+              >
+                <Text fontWeight="bold" color="brand.500">
+                  + Add Document
+                </Text>
+              </Flex>
+            </GridItem>
+            {jsonDocumentsStore.documents ? (
+              jsonDocumentsStore.documents.map((doc) => (
+                <GridItem key={doc.document_id}>
+                  <Card
+                    shadow="md"
+                    _hover={{ shadow: 'lg' }}
+                    cursor="pointer"
+                    onClick={() => handleDocumentClick(doc)}
+                    minHeight="150px"
+                  >
+                    <Flex h="100%" direction="column">
+                      <Heading as="h3" size="md" mb={2} isTruncated>
+                        {doc.name}
+                      </Heading>
+                    </Flex>
+                  </Card>
+                </GridItem>
+              ))
+            ) : (
+              <Text>No documents found</Text>
+            )}
+          </Grid>
+        </Box>
+      )}
+    </Box>
+  );
+});
+
+export default DocumentsPage;

--- a/src/app/(authenticated)/json-document-builder/[[...document_id]]/page.tsx
+++ b/src/app/(authenticated)/json-document-builder/[[...document_id]]/page.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import React, { useEffect } from 'react';
+import { observer } from 'mobx-react-lite';
+import { useRouter } from 'next/navigation';
+import { jsonDocumentBuilderStore } from '@/store/JsonDocumentBuilderStore';
+import { jsonDocumentsStore } from '@/store/JsonDocumentsStore';
+import {
+    Flex,
+    FormControl,
+    FormLabel,
+    Heading,
+    IconButton,
+    Input,
+    Button,
+    Tooltip,
+    Text,
+    useColorMode,
+} from '@chakra-ui/react';
+import { ArrowBackIcon } from '@chakra-ui/icons';
+import MonacoEditor from '@monaco-editor/react';
+import { useAlert } from '@/app/components/AlertProvider';
+
+type Params = Promise<{ document_id: string[] }>;
+
+interface PageProps {
+    params: Params;
+}
+
+const JsonDocumentBuilderPage = observer(({ params }: PageProps) => {
+    const router = useRouter();
+    const { showAlert } = useAlert();
+
+    useEffect(() => {
+        jsonDocumentBuilderStore.setShowAlert(showAlert);
+        loadDocumentId();
+        return () => {
+            jsonDocumentBuilderStore.reset();
+        }
+    }, []);
+
+    const loadDocumentId = async () => {
+        const paramArray = (await params).document_id ?? undefined;
+        const id = paramArray ? paramArray[0] : undefined;
+        if (!id) {
+            jsonDocumentBuilderStore.setIsNewDocument(true);
+            return;
+        }
+        await jsonDocumentsStore.loadDocuments();
+        const doc = jsonDocumentsStore.documents?.find(d => d.document_id === id);
+        if (doc) {
+            jsonDocumentBuilderStore.setDocument(doc);
+        } else {
+            showAlert({
+                title: 'Error',
+                message: 'Could not find document',
+            })
+            router.push('/documents');
+        }
+    }
+
+    const onSaveDocument = async () => {
+        await jsonDocumentBuilderStore.onSaveDocumentClick();
+        jsonDocumentsStore.loadDocuments(true);
+        window.history.back();
+    }
+
+    const onDeleteDocumentClick = async () => {
+        showAlert({
+            title: 'Delete Document',
+            message: 'Are you sure you want to delete this document?',
+            actions: [
+                { label: 'Cancel', onClick: () => { } },
+                {
+                    label: 'Delete',
+                    onClick: async () => {
+                        await jsonDocumentBuilderStore.deleteDocument();
+                        jsonDocumentsStore.loadDocuments(true);
+                        window.history.back();
+                    }
+                }
+            ]
+        })
+    }
+
+    return (
+        <Flex p={4} direction="column" alignItems="center" h="100%" w="100%">
+            <Flex direction="row" w="100%" mb={4} gap={4} align="center">
+                <IconButton
+                    aria-label="Back"
+                    icon={<ArrowBackIcon />}
+                    variant="ghost"
+                    color="inherit"
+                    _hover={{ bg: 'gray.200', _dark: { bg: 'gray.700' } }}
+                    onClick={() => window.history.back()}
+                />
+                <Heading flex="1">Document Builder</Heading>
+            </Flex>
+            <Flex direction="column" w="100%" gap={6}>
+                <FormControl>
+                    <FormLabel>Name</FormLabel>
+                    <Input
+                        value={jsonDocumentBuilderStore.document.name}
+                        onChange={(e) => jsonDocumentBuilderStore.setName(e.target.value)}
+                    />
+                </FormControl>
+                <FormControl>
+                    <FormLabel>Data</FormLabel>
+                    <MonacoEditor
+                        height="60vh"
+                        defaultLanguage="json"
+                        value={jsonDocumentBuilderStore.dataString}
+                        onChange={(value) => jsonDocumentBuilderStore.setDataString(value ?? '')}
+                        theme={useColorMode().colorMode === 'dark' ? 'vs-dark' : 'vs'}
+                        options={{
+                            minimap: { enabled: false },
+                            fontSize: 16,
+                            lineNumbersMinChars: 1,
+                            scrollBeyondLastLine: false,
+                            scrollbar: {
+                                alwaysConsumeMouseWheel: false
+                            },
+                        }}
+                    />
+                    {jsonDocumentBuilderStore.dataError && (
+                        <Text color="red.500" mt={2}>{jsonDocumentBuilderStore.dataError}</Text>
+                    )}
+                </FormControl>
+                <Tooltip
+                    isDisabled={!(!jsonDocumentBuilderStore.document.name || jsonDocumentBuilderStore.dataError)}
+                    label="You must enter a name and valid JSON to save"
+                    fontSize="md"
+                >
+                    <Button
+                        onClick={onSaveDocument}
+                        colorScheme="purple"
+                        size="lg"
+                        disabled={!jsonDocumentBuilderStore.document.name || !!jsonDocumentBuilderStore.dataError}
+                        isLoading={jsonDocumentBuilderStore.saving}
+                    >Save</Button>
+                </Tooltip>
+                {jsonDocumentBuilderStore.document.document_id && (
+                    <Button
+                        onClick={onDeleteDocumentClick}
+                        variant="outline"
+                        size="lg"
+                        isLoading={jsonDocumentBuilderStore.deleting}
+                    >Delete Document</Button>
+                )}
+            </Flex>
+        </Flex>
+    );
+});
+
+export default JsonDocumentBuilderPage;

--- a/src/store/JsonDocumentBuilderStore.ts
+++ b/src/store/JsonDocumentBuilderStore.ts
@@ -1,0 +1,125 @@
+import { makeAutoObservable } from 'mobx';
+import { JsonDocument } from '@/types/jsondocument';
+import { ShowAlertParams } from '@/app/components/AlertProvider';
+import { createJsonDocument } from '@/api/jsondocument/createJsonDocument';
+import { updateJsonDocument } from '@/api/jsondocument/updateJsonDocument';
+import { deleteJsonDocument } from '@/api/jsondocument/deleteJsonDocument';
+
+const defaultDocument: JsonDocument = {
+    document_id: '',
+    name: '',
+    data: {},
+};
+
+class JsonDocumentBuilderStore {
+    showAlert: (params: ShowAlertParams) => void | undefined = () => undefined;
+    document: JsonDocument = { ...defaultDocument };
+    dataString = '{}';
+    dataError: string | null = null;
+    isNewDocument = false;
+    saving = false;
+    deleting = false;
+
+    constructor() {
+        makeAutoObservable(this);
+    }
+
+    reset = () => {
+        this.document = { ...defaultDocument };
+        this.dataString = '{}';
+        this.dataError = null;
+        this.isNewDocument = false;
+        this.saving = false;
+        this.deleting = false;
+    }
+
+    setShowAlert = (showAlert: (params: ShowAlertParams) => void) => {
+        this.showAlert = showAlert;
+    }
+
+    setIsNewDocument(isNew: boolean) {
+        this.isNewDocument = isNew;
+    }
+
+    setDocument(document: JsonDocument) {
+        this.document = document;
+        this.dataString = JSON.stringify(document.data, null, 2);
+        this.dataError = null;
+    }
+
+    setName(name: string) {
+        this.document.name = name;
+    }
+
+    setDataString(value: string) {
+        this.dataString = value;
+        try {
+            this.document.data = JSON.parse(value);
+            this.dataError = null;
+        } catch (err) {
+            this.dataError = (err as Error).message;
+        }
+    }
+
+    async createDocument() {
+        try {
+            this.saving = true;
+            const doc = await createJsonDocument({
+                name: this.document.name,
+                data: this.document.data,
+            });
+            this.document = doc;
+        } catch (error) {
+            this.showAlert({
+                title: 'Error',
+                message: (error as Error).message,
+            })
+        } finally {
+            this.saving = false;
+        }
+    }
+
+    async updateDocument() {
+        try {
+            this.saving = true;
+            const doc = await updateJsonDocument({
+                document_id: this.document.document_id,
+                name: this.document.name,
+                data: this.document.data,
+            });
+            this.document = doc;
+        } catch (error) {
+            this.showAlert({
+                title: 'Error',
+                message: (error as Error).message,
+            })
+        } finally {
+            this.saving = false;
+        }
+    }
+
+    async deleteDocument() {
+        try {
+            this.deleting = true;
+            await deleteJsonDocument(this.document.document_id);
+        } catch (error) {
+            this.showAlert({
+                title: 'Error',
+                message: (error as Error).message,
+            })
+        } finally {
+            this.deleting = false;
+        }
+    }
+
+    async onSaveDocumentClick() {
+        if (this.document.document_id) {
+            await this.updateDocument();
+        } else {
+            await this.createDocument();
+        }
+        this.isNewDocument = false;
+    }
+}
+
+export const jsonDocumentBuilderStore = new JsonDocumentBuilderStore();

--- a/src/store/JsonDocumentsStore.ts
+++ b/src/store/JsonDocumentsStore.ts
@@ -1,0 +1,42 @@
+import { makeAutoObservable } from 'mobx';
+import { getJsonDocuments } from '@/api/jsondocument/getJsonDocuments';
+import { JsonDocument } from '@/types/jsondocument';
+import { ShowAlertParams } from "@/app/components/AlertProvider";
+
+class JsonDocumentsStore {
+    showAlert: (params: ShowAlertParams) => void | undefined = () => undefined;
+    documents: JsonDocument[] | undefined = undefined;
+    documentsLoading = true;
+
+    constructor() {
+        makeAutoObservable(this);
+    }
+
+    setShowAlert = (showAlert: (params: ShowAlertParams) => void) => {
+        this.showAlert = showAlert;
+    }
+
+    async loadDocuments(force: boolean = false) {
+        if (!force && this.documents) {
+            return;
+        }
+
+        try {
+            this.documentsLoading = true;
+            this.documents = await getJsonDocuments();
+        } catch (error) {
+            this.showAlert({
+                title: "Whoops",
+                message: (error as Error).message
+            })
+        } finally {
+            this.documentsLoading = false;
+        }
+    }
+
+    reset = () => {
+        this.documents = undefined;
+    }
+}
+
+export const jsonDocumentsStore = new JsonDocumentsStore();

--- a/src/types/jsondocument.ts
+++ b/src/types/jsondocument.ts
@@ -1,0 +1,5 @@
+export interface JsonDocument {
+    document_id: string;
+    name: string;
+    data: Record<string, unknown>;
+}


### PR DESCRIPTION
## Summary
- add JsonDocument type and API helpers
- create stores and pages for managing JSON documents
- hook up editor with Monaco for JSON editing & validation
- integrate Documents section in sidebar navigation

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847e523b1c88327ab65d03ff7c13455