### PR TITLE
Add Jira tools tab to agent builder

### DIFF
--- a/src/app/(authenticated)/agent-builder/[[...agent_id]]/components/JiraTools.tsx
+++ b/src/app/(authenticated)/agent-builder/[[...agent_id]]/components/JiraTools.tsx
@@ -1,0 +1,92 @@
+import React, { useEffect } from "react";
+import { observer } from "mobx-react-lite";
+import { Flex, Heading, Text } from "@chakra-ui/react";
+import { agentBuilderStore } from "@/store/AgentBuilderStore";
+import { integrationsStore } from "@/store/IntegrationsStore";
+import { Tool } from "@/types/tools";
+
+const jiraTools: Tool[] = [
+    {
+        tool_id: 'jira_create_issue',
+        org_id: 'jira',
+        name: 'Create Issue',
+        description: 'Create a new Jira issue.'
+    },
+    {
+        tool_id: 'jira_search_issues',
+        org_id: 'jira',
+        name: 'Search Issues',
+        description: 'Search Jira issues in a project.'
+    },
+    {
+        tool_id: 'jira_transition_issue',
+        org_id: 'jira',
+        name: 'Transition Issue',
+        description: 'Move an issue to a new state.'
+    },
+    {
+        tool_id: 'jira_assign_issue',
+        org_id: 'jira',
+        name: 'Assign Issue',
+        description: 'Assign a Jira issue to a user.'
+    },
+    {
+        tool_id: 'jira_manage_sprints',
+        org_id: 'jira',
+        name: 'Manage Sprints',
+        description: 'Create and manage Jira sprints.'
+    }
+];
+
+export const JiraTools = observer(() => {
+    useEffect(() => {
+        integrationsStore.loadIntegrations();
+    }, []);
+
+    const hasJiraIntegration = integrationsStore.integrations?.some(
+        (integration) => integration.type === 'jira'
+    );
+
+    const addOrRemoveTool = (tool: Tool) => {
+        if (agentBuilderStore.currentAgent?.tools?.includes(tool.tool_id)) {
+            agentBuilderStore.removeTool(tool);
+        } else {
+            agentBuilderStore.addTool(tool);
+        }
+    };
+
+    if (!hasJiraIntegration) {
+        return (
+            <Flex direction="column" gap={4} pb={4}>
+                <Heading size="md">Jira Tools</Heading>
+                <Text>Connect a Jira integration to use these tools.</Text>
+            </Flex>
+        );
+    }
+
+    return (
+        <Flex direction="column" gap={4} pb={4}>
+            <Flex direction="row" justify="space-between" align="center">
+                <Heading size="md">Jira Tools</Heading>
+            </Flex>
+            <Flex direction="column" gap={2}>
+                {jiraTools.map((tool, index) => (
+                    <Flex
+                        key={index}
+                        direction="column"
+                        gap={2}
+                        p={2}
+                        borderWidth="1px"
+                        borderRadius="md"
+                        border={agentBuilderStore.currentAgent?.tools?.includes(tool.tool_id) ? '2px solid' : ''}
+                        onClick={() => addOrRemoveTool(tool)}
+                        cursor="pointer"
+                    >
+                        <Heading size="sm">{tool.name}</Heading>
+                        <Text>{tool.description}</Text>
+                    </Flex>
+                ))}
+            </Flex>
+        </Flex>
+    );
+});

--- a/src/app/(authenticated)/agent-builder/[[...agent_id]]/page.tsx
+++ b/src/app/(authenticated)/agent-builder/[[...agent_id]]/page.tsx
@@ -21,6 +21,8 @@ import { observer } from "mobx-react-lite";
 import { PassEventTool } from "./components/PassEventTool";
 import { Tool } from "@/types/tools";
 import { CustomAgentTools } from "./components/CustomAgentTools";
+import { JiraTools } from "./components/JiraTools";
+import { integrationsStore } from "@/store/IntegrationsStore";
 
 type Params = Promise<{ agent_id: string[] }>;
 
@@ -40,10 +42,12 @@ const AgentBuilderPage = observer(({ params }: AgentBuilderPageProps) => {
     const { isOpen: isToolPickerModalOpen, onOpen: onOpenToolPickerModal, onClose: onCloseToolPickerModal } = useDisclosure();
     const { hasCopied, onCopy } = useClipboard(agentBuilderStore.showAgentId ? agentBuilderStore.currentAgent.agent_id : '');
     const { showAlert } = useAlert();
+    const hasJiraIntegration = integrationsStore.integrations?.some((i) => i.type === 'jira');
 
     useEffect(() => {
         setShowAlertOnStore();
         loadAgentId();
+        integrationsStore.loadIntegrations();
 
         return () => {
             agentBuilderStore.reset();
@@ -173,6 +177,8 @@ const AgentBuilderPage = observer(({ params }: AgentBuilderPageProps) => {
                 return <PassEventTool />;
             case 'custom_code':
                 return <CustomAgentTools />;
+            case 'jira_tools':
+                return <JiraTools />;
             default:
                 return <Text>Tool not implemented yet</Text>;
         }
@@ -387,7 +393,9 @@ const AgentBuilderPage = observer(({ params }: AgentBuilderPageProps) => {
                         <Flex direction="column" gap={4}>
                             {/* Tool tab menue */}
                             <Flex direction="row" gap={4}>
-                                {agentBuilderStore.agentTools.map((toolName, index) => (
+                                {agentBuilderStore.agentTools
+                                    .filter((toolName) => toolName !== 'jira_tools' || hasJiraIntegration)
+                                    .map((toolName, index) => (
                                     <Button
                                         key={index}
                                         variant={agentBuilderStore.presentedAgentTool === toolName ? 'solid' : 'outline'}

--- a/src/store/AgentBuilderStore.ts
+++ b/src/store/AgentBuilderStore.ts
@@ -55,7 +55,7 @@ class AgentBuilderStore {
     agentTools: string[] = [
         'pass_event',
         'custom_code',
-        'api_call'
+        'jira_tools'
     ]
     presentedAgentTool: string = 'pass_event';
 


### PR DESCRIPTION
## Summary
- add static Jira tools list component
- show Jira tools tab instead of API call
- load integrations on agent builder page and show tab only when Jira is connected

## Testing
- `npm run lint` *(fails: next not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_684a8eeab2c88327b56a5a2943c76fba