### PR TITLE
Add initialization tool support for agents

### DIFF
--- a/src/api/agent/createAgent.ts
+++ b/src/api/agent/createAgent.ts
@@ -11,6 +11,7 @@ interface CreateAgentPayload {
     voice_id?: string;
     tools?: string[];
     uses_prompt_args?: boolean;
+    initialize_tool_id?: string | null;
 }
 
 export async function createAgent(payload: CreateAgentPayload): Promise<Agent> {

--- a/src/api/agent/updateAgent.ts
+++ b/src/api/agent/updateAgent.ts
@@ -12,6 +12,7 @@ interface UpdateAgentPayload {
     voice_id?: string;
     tools?: string[];
     uses_prompt_args?: boolean;
+    initialize_tool_id?: string | null;
 }
 
 export async function updateAgent(payload: UpdateAgentPayload): Promise<Agent> {

--- a/src/api/tool/createTool.ts
+++ b/src/api/tool/createTool.ts
@@ -7,6 +7,7 @@ interface CreateToolPayload {
     description?: string;
     pd_id?: string;
     code?: string;
+    pass_context?: boolean;
 }
 
 export async function createTool(payload: CreateToolPayload): Promise<Tool> {

--- a/src/api/tool/updateTool.ts
+++ b/src/api/tool/updateTool.ts
@@ -8,6 +8,7 @@ interface UpdateToolPayload {
     description?: string;
     pd_id?: string;
     code?: string;
+    pass_context?: boolean;
 }
 
 export async function updateTool(payload: UpdateToolPayload): Promise<Tool> {

--- a/src/app/(authenticated)/agent-builder/[[...agent_id]]/page.tsx
+++ b/src/app/(authenticated)/agent-builder/[[...agent_id]]/page.tsx
@@ -6,7 +6,7 @@ import {
     Flex, Text, FormControl, Heading, IconButton, Input, Switch, Textarea, Button, Tooltip,
     useDisclosure, Modal, ModalBody, ModalCloseButton, ModalContent, ModalHeader, ModalOverlay,
     Drawer, DrawerBody, DrawerContent, DrawerHeader, DrawerOverlay, DrawerCloseButton,
-    Tag, TagLabel, TagCloseButton, useColorMode, useClipboard, FormLabel, Spinner
+    Tag, TagLabel, TagCloseButton, useColorMode, useClipboard, FormLabel, Spinner, Select
 } from "@chakra-ui/react";
 import { ArrowBackIcon, CheckIcon, CopyIcon } from "@chakra-ui/icons";
 import ChatBox, { defaultChatBoxStyle, defaultDarkChatBoxStyle } from "@/app/components/chatbox/ChatBox";
@@ -22,6 +22,7 @@ import { Tool } from "@/types/tools";
 import { CustomAgentTools } from "./components/CustomAgentTools";
 import { MemoryTools } from "./components/MemoryTools";
 import { WebSearchTools } from "./components/WebSearchTools";
+import { toolsStore } from "@/store/ToolsStore";
 
 type Params = Promise<{ agent_id: string[] }>;
 
@@ -45,6 +46,7 @@ const AgentBuilderPage = observer(({ params }: AgentBuilderPageProps) => {
     useEffect(() => {
         setShowAlertOnStore();
         loadAgentId();
+        toolsStore.loadTools();
 
         return () => {
             agentBuilderStore.reset();
@@ -304,6 +306,28 @@ const AgentBuilderPage = observer(({ params }: AgentBuilderPageProps) => {
                             isChecked={agentBuilderStore.currentAgent.agent_speaks_first}
                             onChange={(e) => agentBuilderStore.setBooleanField("agent_speaks_first", e.target.checked)}
                         />
+                    </FormControl>
+
+                    {/* Initialization Tool */}
+                    <FormControl>
+                        <FormLabelToolTip
+                            label="Initialization Tool"
+                            tooltip="This tool will run automatically whenever a new conversation context is created with this agent—useful for setup, greetings, fetching context, etc."
+                        />
+                        {toolsStore.toolsLoading ? (
+                            <Spinner mt={2} size="sm" />
+                        ) : (
+                            <Select
+                                mt={2}
+                                placeholder="None"
+                                value={agentBuilderStore.currentAgent.initialize_tool_id || ''}
+                                onChange={(e) => agentBuilderStore.setInitializeToolId(e.target.value || null)}
+                            >
+                                {toolsStore.tools && toolsStore.tools.map((tool) => (
+                                    <option key={tool.tool_id} value={tool.tool_id}>{tool.name}</option>
+                                ))}
+                            </Select>
+                        )}
                     </FormControl>
 
                     {/* Prompt Args Toggle */}

--- a/src/app/(authenticated)/tool-builder/[[...tool_id]]/page.tsx
+++ b/src/app/(authenticated)/tool-builder/[[...tool_id]]/page.tsx
@@ -4,7 +4,7 @@ import React, { useEffect } from "react";
 import {
     Flex, FormControl, Heading, IconButton, Input, Button, Tooltip,
     useColorMode,
-    Spinner
+    Spinner, Switch
 } from "@chakra-ui/react";
 import { ArrowBackIcon } from "@chakra-ui/icons";
 import { FormLabelToolTip } from "@/app/components/FormLableToolTip";
@@ -150,6 +150,22 @@ const ToolBuilderPage = observer(({ params }: ToolBuilderPageProps) => {
                     />
                 </FormControl>
 
+                {/* Pass Context Toggle */}
+                <FormControl display="flex" alignItems="center">
+                    <FormLabelToolTip
+                        label="Pass Context"
+                        tooltip="Include context object as a parameter to this tool call."
+                    />
+                    <Switch
+                        ml={2}
+                        colorScheme="purple"
+                        size="lg"
+                        isChecked={toolBuilderStore.tool.pass_context}
+                        onChange={(e) => toolBuilderStore.setPassContext(e.target.checked)}
+                    />
+                </FormControl>
+
+
                 {/* Parameters */}
                 {toolBuilderStore.isLoadingParameterDefinition ? (
                     <Flex justify="center" align="center" height="200px">
@@ -207,13 +223,20 @@ const ToolBuilderPage = observer(({ params }: ToolBuilderPageProps) => {
                 </Flex>
 
                 {/* Test Input Button */}
-                <Button
-                    onClick={() => toolBuilderStore.executeTestInput()}
-                    colorScheme="purple"
-                    size="lg"
-                    variant={'outline'}
-                    isLoading={toolBuilderStore.toolExecuting}
-                >Test</Button>
+                <Tooltip
+                    isDisabled={!toolBuilderStore.tool.pass_context}
+                    label="Currently the test feature is only available when pass context is disabled"
+                    fontSize="md"
+                >
+                    <Button
+                        onClick={() => toolBuilderStore.executeTestInput()}
+                        colorScheme="purple"
+                        size="lg"
+                        variant={'outline'}
+                        isLoading={toolBuilderStore.toolExecuting}
+                        isDisabled={toolBuilderStore.tool.pass_context}
+                    >Test</Button>
+                </Tooltip>
 
                 {/* Save Button */}
                 <Tooltip

--- a/src/store/AgentBuilderStore.ts
+++ b/src/store/AgentBuilderStore.ts
@@ -38,6 +38,7 @@ class AgentBuilderStore {
         is_public: false,
         agent_speaks_first: false,
         uses_prompt_args: false,
+        initialize_tool_id: null,
         prompt: '',
         tools: [],
     };
@@ -92,6 +93,7 @@ class AgentBuilderStore {
             is_public: false,
             agent_speaks_first: false,
             uses_prompt_args: false,
+            initialize_tool_id: null,
             prompt: '',
             tools: [],
         };
@@ -208,6 +210,7 @@ class AgentBuilderStore {
                 voice_id: this.currentAgent.voice_id,
                 tools: this.currentAgent.tools,
                 uses_prompt_args: this.currentAgent.uses_prompt_args,
+                initialize_tool_id: this.currentAgent.initialize_tool_id,
             });
             this.currentAgent = agent;
             this.hasUpdates = false;
@@ -241,6 +244,7 @@ class AgentBuilderStore {
                 voice_id: this.currentAgent.voice_id,
                 tools: this.currentAgent.tools,
                 uses_prompt_args: this.currentAgent.uses_prompt_args,
+                initialize_tool_id: this.currentAgent.initialize_tool_id,
             });
             this.currentAgent = agent;
             this.hasUpdates = false;
@@ -388,6 +392,11 @@ class AgentBuilderStore {
 
     setPresentedAgentTool(tool: string) {
         this.presentedAgentTool = tool;
+    }
+
+    setInitializeToolId(toolId: string | null) {
+        this.currentAgent.initialize_tool_id = toolId;
+        this.hasUpdates = true;
     }
 }
 export const agentBuilderStore = new AgentBuilderStore();

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -6,6 +6,7 @@ export interface Agent {
     agent_speaks_first: boolean;
     voice_id?: string;
     uses_prompt_args?: boolean;
+    initialize_tool_id?: string | null;
     prompt: string;
     tools?:  string[];
 }

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -7,6 +7,7 @@ export interface Tool {
     description?: string;
     pd_id?: string;
     code?: string;
+    pass_context?: boolean;
 }
 
 export interface TestInput {


### PR DESCRIPTION
## Summary
- allow setting an initialization tool when creating or editing an agent
- propagate `initialize_tool_id` through API payloads and agent store
- load organization tools in the agent builder
- add a dropdown in the agent builder UI for selecting the initialization tool

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867e3879e748327955c559424ff9ca1