### PR TITLE
plan(10): research validation + sequential agent lineage reframe

### DIFF
--- a/Prompts/plans/10-frontend-foundations.md
+++ b/Prompts/plans/10-frontend-foundations.md
@@ -65,7 +65,11 @@ From the 2026-05-04 frontend audit, re-checked against the codebase 2026-05-07. 
 
 ## Order of operations
 
-This section is read first by the executing agent. **Each deliverable below is its own PR. Ship them in order. Each must pass `lint`, `typecheck`, `test`, and `next build` on its own — do not stack one on top of another in flight.**
+This section is read first by the executing agent. **This plan is executed as a sequential agent lineage on a single feature branch.** Each deliverable is implemented by one agent, which commits its work to the branch before the next agent picks up. There is one PR for the whole project; it accumulates commits as deliverables land.
+
+**Quality gate per deliverable:** After completing each deliverable, the implementing agent runs `lint`, `typecheck`, `test`, and `next build` and fixes any failures before committing. The branch must compile and pass checks at every commit — not just at the end.
+
+**Handoff protocol:** Each implementing agent reads this plan, identifies the first unchecked deliverable, implements it fully, runs the quality gate, commits with a message like `feat(10): deliverable A — foundation prep`, and stops. The orchestrator then dispatches the next agent for the following deliverable.
 
 The order is not arbitrary. It reflects three constraints:
 
@@ -82,8 +86,8 @@ Order:
 - **E. Root store + per-store DI** — introduce `ParameterDefinitionsStore`. Construct stores in dep-order, kill module singletons, expose `useStores()` for the dashboard. Construct a separate `<AuthFlowStoreProvider>` in `(auth)/providers.tsx` for the signin/signup pages (its own `AuthStore` + `SignUpStore` instances). Re-bind the API client's auth callbacks to the root-store-owned `authStore`. After this step there is no `export const xxxStore = new XxxStore()` anywhere.
 - **F. Auth gating boundary** — `<DashboardBoot>`, real `/user` validation in `AuthStore.checkAuth`, hardened 401 interceptor (lives in D's chokepoint, wired through E's bindings), coarse middleware gate. Removes the optimistic `signedIn = true` flip from `submitSignIn`.
 - **G. Enable `react-hooks/exhaustive-deps` at error + sweep** — promote the rule (already on at warn via `next/core-web-vitals`) to error level, fix every surviving warning. Of the **15 warnings** present today, roughly 12 are removed as a side effect of C and E/F; G fixes the ~3 that survive.
-- **H. Builder stores: singleton → per-page instance** — one builder per PR (`Tool`, `Agent`, `SRE`, `JsonDocument`). The `ChatPageBuilder` is **not** included — that surface is being deprecated and will be deleted in project 08. Each shipped builder gets a focused domain-logic test.
-- **I. Navigation, prefetch, and segment files** — `<Link>` sweep (excluding deprecated chat-page routes), `DASHBOARD_ROUTES` + `router.prefetch(...)` effect inside `<DashboardBoot>`, `loading.tsx` / `error.tsx` / `not-found.tsx` per segment, `app/sitemap.ts` and `app/robots.ts`. May ship in parallel with H.
+- **H. Builder stores: singleton → per-page instance** — four sequential commits, one per builder (`Tool`, `Agent`, `SRE`, `JsonDocument`), each committed separately to the branch. The `ChatPageBuilder` is **not** included — that surface is being deprecated and will be deleted in project 08. Each converted builder gets a focused domain-logic test before the next builder begins.
+- **I. Navigation, prefetch, and segment files** — `<Link>` sweep (excluding deprecated chat-page routes), `DASHBOARD_ROUTES` + `router.prefetch(...)` effect inside `<DashboardBoot>`, `loading.tsx` / `error.tsx` / `not-found.tsx` per segment, `app/sitemap.ts` and `app/robots.ts`.
 - **J. Webpack fallback cleanup** — investigate `child_process: false` in `next.config.ts`; remove if possible, otherwise leave a comment naming the offending import.
 
 ## Deliverables


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this does

Validates Project 10 (Frontend Foundations) plan against the real codebase and reframes its execution model.

### Phase 1 — Research (10 parallel subagents)

One research agent per deliverable (A–J) read the actual codebase and wrote findings to `Prompts/research/`. Each file documents what EXISTS today with precise file:line references.

### Phase 2 — Plan correction (10 sequential subagents)

One plan agent per deliverable read the research output and made surgical edits to `Prompts/plans/10-frontend-foundations.md` where the plan's assumptions didn't match reality. Key corrections:

- **A**: Added `typecheck` script (missing from `package.json`), CI creation from scratch, 3 whole-file `/* eslint-disable */` files, `no-explicit-any` already active via `next/typescript`
- **B**: Corrected root layout provider stack (NavigationGuardProvider → ChakraProviders → AlertProvider), AlertProvider removal flow, `NavigationGuardProvider` placement post-split, `src/components/` → `src/app/components/` path corrections throughout
- **C**: Page call site count 17→16, `CopyButton.tsx` path fix, `JsonDocumentBuilderStore` already has `dataError` field
- **D**: Added `user/updateUser.ts` to Amplify carve-out, updated file count to 64 fetch-based (61 standard + 3 public-access), added `TokenStreamingService` to WebSocket exclusion list, noted public-access endpoints (`getTool`, `getSRE`) with no auth header
- **E**: Documented the three actual circular import chains (AuthStore ↔ builder stores via module-level singletons), corrected audit item 9 from the example given
- **F**: Clarified `DashboardBoot` replaces (doesn't duplicate) root layout's spinner, corrected per-page redirect removal list, noted `router.replace` is a deliberate change from current `router.push`, added step to remove the authenticated layout's lazy `loadUser()` call after F.2 adds it to `checkAuth()`
- **G**: Corrected warning count (15, not ~17), noted `create-team` reaction survives to G, added `StageAssignmentField.tsx:105` suppression handling
- **H**: Corrected `AgentBuilderStore` constructor deps to `{ agents }` only (tools/models used only in the page, not the store), clarified `JsonDocumentBuilderStore` (134 lines) is already within the LOC target
- **I**: Added `contexts/page.tsx` no-op prefetch note (prefetches itself — delete it), Sidebar Chakra `<Link>` → Next.js `<Link>` import swap requirement, OAuth callback pages exclusion from sweep
- **J**: Corrected fallback scope (global webpack config, not public-side only), framed the real investigation (aws-amplify v6 modular imports), added `@next/bundle-analyzer` install step

### Phase 3 — Execution model reframe

Replaced "each deliverable is its own PR" with a **sequential agent lineage on a single feature branch**:
- One implement agent per deliverable, commits to branch after quality gate passes
- H builder decomposition: four sequential commits on the same branch, not four PRs
- Handoff protocol documented for orchestrator + implement agents

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-43c9e749-efb9-4aec-ba2a-1d8a2888246c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-43c9e749-efb9-4aec-ba2a-1d8a2888246c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

