### PR TITLE
feat: restyle sign-up flow with shadcn + Tailwind

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "framer-motion": "^11.13.1",
+        "input-otp": "^1.4.2",
         "lucide-react": "^1.14.0",
         "marked": "^15.0.7",
         "mobx": "^6.13.5",
@@ -9353,6 +9354,16 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/input-otp": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/input-otp/-/input-otp-1.4.2.tgz",
+      "integrity": "sha512-l3jWwYNvrEa6NTCt7BECfCm48GvwuZzkoeG3gBL2w4CHeOXW3eKFmf9UNYkNfYc3mxMrthMnxjIE07MT0zLBQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/internal-slot": {
       "version": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "framer-motion": "^11.13.1",
+    "input-otp": "^1.4.2",
     "lucide-react": "^1.14.0",
     "marked": "^15.0.7",
     "mobx": "^6.13.5",

--- a/src/app/(auth)/signup/components/CreateOrganizationStep.tsx
+++ b/src/app/(auth)/signup/components/CreateOrganizationStep.tsx
@@ -1,29 +1,74 @@
 'use client';
 
 import React from 'react';
-import { Stack, FormControl, FormLabel, Input, Button, Heading } from '@chakra-ui/react';
 import { observer } from 'mobx-react-lite';
 import { useAuthFlowStores } from '@/store/AuthFlowStoreContext';
-import { InlineError } from '@/app/components/InlineError';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { Building2 } from 'lucide-react';
 
 const CreateOrganizationStep = observer(() => {
     const { signUp: signUpStore } = useAuthFlowStores();
+
+    const handleSubmit = (e: React.FormEvent) => {
+        e.preventDefault();
+        signUpStore.createOrganization();
+    };
+
     return (
-        <Stack spacing={4}>
-            <Heading as="h1" size="lg" textAlign="center">
-                Create Your Organization
-            </Heading>
-            <FormControl isRequired>
-                <FormLabel>Organization Name</FormLabel>
-                <Input value={signUpStore.organizationName} onChange={(e) => signUpStore.setField('organizationName', e.target.value)} />
-            </FormControl>
-            {signUpStore.createOrgError && (
-                <InlineError message={signUpStore.createOrgError} />
-            )}
-            <Button isLoading={signUpStore.createOrgLoading} onClick={() => signUpStore.createOrganization()}>
-                Create Organization
-            </Button>
-        </Stack>
+        <div>
+            <div className="mb-6">
+                <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-xl bg-brand-500/10">
+                    <Building2 className="size-5 text-brand-500" />
+                </div>
+                <h1 className="text-xl font-semibold tracking-tight text-foreground">
+                    Set up your workspace
+                </h1>
+                <p className="mt-1 text-sm text-muted-foreground">
+                    Give your organization a name. You can always change this later.
+                </p>
+            </div>
+
+            <form onSubmit={handleSubmit} className="space-y-4">
+                <div className="space-y-1.5">
+                    <Label htmlFor="orgName">Organization name</Label>
+                    <Input
+                        id="orgName"
+                        placeholder="Acme Corp"
+                        value={signUpStore.organizationName}
+                        onChange={(e) =>
+                            signUpStore.setField('organizationName', e.target.value)
+                        }
+                        required
+                    />
+                    <p className="text-xs text-muted-foreground">
+                        This is the name of your team or company.
+                    </p>
+                </div>
+
+                {signUpStore.createOrgError && (
+                    <div className="rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2.5 text-sm text-destructive">
+                        {signUpStore.createOrgError}
+                    </div>
+                )}
+
+                <Button
+                    type="submit"
+                    className="mt-1 w-full"
+                    disabled={signUpStore.createOrgLoading}
+                >
+                    {signUpStore.createOrgLoading ? (
+                        <span className="flex items-center gap-2">
+                            <span className="size-4 animate-spin rounded-full border-2 border-primary-foreground/30 border-t-primary-foreground" />
+                            Creating workspace…
+                        </span>
+                    ) : (
+                        'Create workspace'
+                    )}
+                </Button>
+            </form>
+        </div>
     );
 });
 

--- a/src/app/(auth)/signup/components/SuccessStep.tsx
+++ b/src/app/(auth)/signup/components/SuccessStep.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import React from 'react';
-import { Stack, Button, Heading, Text } from '@chakra-ui/react';
 import { useRouter } from 'next/navigation';
 import { useAuthFlowStores } from '@/store/AuthFlowStoreContext';
+import { Button } from '@/components/ui/button';
+import { CheckCircle2, ArrowRight } from 'lucide-react';
 
 const SuccessStep = () => {
     const router = useRouter();
@@ -12,18 +13,35 @@ const SuccessStep = () => {
     const handleGoToHome = async () => {
         await auth.checkAuth();
         router.push('/');
-    }
+    };
 
     return (
-        <Stack spacing={4} textAlign="center">
-            <Heading as="h1" size="lg">
-                Account Created Successfully!
-            </Heading>
-            <Text>Welcome to Ajentify! You’re all set to get started.</Text>
-            <Button bg="green.500" _hover={{bg: "green.300"}} onClick={handleGoToHome}>
-                Go to Home
-            </Button>
-        </Stack>
+        <div className="flex flex-col items-center py-4 text-center">
+            <div className="relative mb-5">
+                <div className="flex h-16 w-16 items-center justify-center rounded-full bg-brand-500/10">
+                    <CheckCircle2
+                        className="size-9 text-brand-500"
+                        strokeWidth={1.5}
+                    />
+                </div>
+                {/* Subtle ring animation */}
+                <div className="absolute inset-0 animate-ping rounded-full bg-brand-500/10 [animation-duration:2s] [animation-iteration-count:3]" />
+            </div>
+
+            <h1 className="text-2xl font-semibold tracking-tight text-foreground">
+                You&apos;re all set!
+            </h1>
+            <p className="mt-2 max-w-[260px] text-sm text-muted-foreground">
+                Welcome to Ajentify. Your account and workspace are ready to go.
+            </p>
+
+            <div className="mt-8 flex w-full flex-col gap-2">
+                <Button className="w-full gap-2" onClick={handleGoToHome}>
+                    Get started
+                    <ArrowRight className="size-4" />
+                </Button>
+            </div>
+        </div>
     );
 };
 

--- a/src/app/(auth)/signup/components/UserDetailsStep.tsx
+++ b/src/app/(auth)/signup/components/UserDetailsStep.tsx
@@ -1,56 +1,119 @@
 'use client';
 
 import React from 'react';
-import { Stack, FormControl, FormLabel, Input, Button, Heading } from '@chakra-ui/react';
 import { observer } from 'mobx-react-lite';
 import { useAuthFlowStores } from '@/store/AuthFlowStoreContext';
-import { InlineError } from '@/app/components/InlineError';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { UserIcon } from 'lucide-react';
 
 const UserDetailsStep = observer(() => {
     const { signUp: signUpStore } = useAuthFlowStores();
+
+    const handleSubmit = (e: React.FormEvent) => {
+        e.preventDefault();
+        signUpStore.submitSignUp();
+    };
+
     return (
-        <Stack
-            spacing={4}
-            width="100%"
-            justifyContent="center"
-            alignItems="center"
-            px={4}
-        >
-            <Heading as="h1" size="lg" textAlign="center">
-                Sign Up
-            </Heading>
-            <FormControl isRequired>
-                <FormLabel>First Name</FormLabel>
-                <Input value={signUpStore.firstName} placeholder='Thomas' onChange={(e) => signUpStore.setField('firstName', e.target.value)} />
-            </FormControl>
-            <FormControl isRequired>
-                <FormLabel>Last Name</FormLabel>
-                <Input value={signUpStore.lastName} placeholder='Anderson' onChange={(e) => signUpStore.setField('lastName', e.target.value)} />
-            </FormControl>
-            <FormControl isRequired>
-                <FormLabel>Email</FormLabel>
-                <Input type="email" value={signUpStore.email} placeholder='neo@matrix.ai' onChange={(e) => signUpStore.setField('email', e.target.value)} />
-            </FormControl>
-            <FormControl isRequired>
-                <FormLabel>Password</FormLabel>
-                <Input type="password" value={signUpStore.password} placeholder='Enter your password' onChange={(e) => signUpStore.setField('password', e.target.value)} />
-            </FormControl>
-            <FormControl isRequired>
-                <FormLabel>Confirm Password</FormLabel>
-                <Input
-                    type="password"
-                    value={signUpStore.confirmPassword}
-                    placeholder='Confirm your password'
-                    onChange={(e) => signUpStore.setField('confirmPassword', e.target.value)}
-                />
-            </FormControl>
-            {signUpStore.signUpError && (
-                <InlineError message={signUpStore.signUpError} />
-            )}
-            <Button width="100%" isLoading={signUpStore.signUpLoading} onClick={() => signUpStore.submitSignUp()}>
-                Sign Up
-            </Button>
-        </Stack>
+        <div>
+            <div className="mb-6">
+                <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-xl bg-brand-500/10">
+                    <UserIcon className="size-5 text-brand-500" />
+                </div>
+                <h1 className="text-xl font-semibold tracking-tight text-foreground">
+                    Create your account
+                </h1>
+                <p className="mt-1 text-sm text-muted-foreground">
+                    Start your journey with Ajentify today
+                </p>
+            </div>
+
+            <form onSubmit={handleSubmit} className="space-y-4">
+                <div className="grid grid-cols-2 gap-3">
+                    <div className="space-y-1.5">
+                        <Label htmlFor="firstName">First name</Label>
+                        <Input
+                            id="firstName"
+                            placeholder="Thomas"
+                            value={signUpStore.firstName}
+                            onChange={(e) => signUpStore.setField('firstName', e.target.value)}
+                            required
+                        />
+                    </div>
+                    <div className="space-y-1.5">
+                        <Label htmlFor="lastName">Last name</Label>
+                        <Input
+                            id="lastName"
+                            placeholder="Anderson"
+                            value={signUpStore.lastName}
+                            onChange={(e) => signUpStore.setField('lastName', e.target.value)}
+                            required
+                        />
+                    </div>
+                </div>
+
+                <div className="space-y-1.5">
+                    <Label htmlFor="email">Email address</Label>
+                    <Input
+                        id="email"
+                        type="email"
+                        placeholder="neo@matrix.ai"
+                        value={signUpStore.email}
+                        onChange={(e) => signUpStore.setField('email', e.target.value)}
+                        required
+                    />
+                </div>
+
+                <div className="space-y-1.5">
+                    <Label htmlFor="password">Password</Label>
+                    <Input
+                        id="password"
+                        type="password"
+                        placeholder="Create a strong password"
+                        value={signUpStore.password}
+                        onChange={(e) => signUpStore.setField('password', e.target.value)}
+                        required
+                    />
+                </div>
+
+                <div className="space-y-1.5">
+                    <Label htmlFor="confirmPassword">Confirm password</Label>
+                    <Input
+                        id="confirmPassword"
+                        type="password"
+                        placeholder="Confirm your password"
+                        value={signUpStore.confirmPassword}
+                        onChange={(e) =>
+                            signUpStore.setField('confirmPassword', e.target.value)
+                        }
+                        required
+                    />
+                </div>
+
+                {signUpStore.signUpError && (
+                    <div className="rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2.5 text-sm text-destructive">
+                        {signUpStore.signUpError}
+                    </div>
+                )}
+
+                <Button
+                    type="submit"
+                    className="mt-1 w-full"
+                    disabled={signUpStore.signUpLoading}
+                >
+                    {signUpStore.signUpLoading ? (
+                        <span className="flex items-center gap-2">
+                            <span className="size-4 animate-spin rounded-full border-2 border-primary-foreground/30 border-t-primary-foreground" />
+                            Creating account…
+                        </span>
+                    ) : (
+                        'Continue'
+                    )}
+                </Button>
+            </form>
+        </div>
     );
 });
 

--- a/src/app/(auth)/signup/components/VerificationStep.tsx
+++ b/src/app/(auth)/signup/components/VerificationStep.tsx
@@ -1,29 +1,85 @@
 'use client';
 
 import React from 'react';
-import { Stack, FormControl, FormLabel, Input, Button, Heading } from '@chakra-ui/react';
 import { observer } from 'mobx-react-lite';
 import { useAuthFlowStores } from '@/store/AuthFlowStoreContext';
-import { InlineError } from '@/app/components/InlineError';
+import { Button } from '@/components/ui/button';
+import {
+    InputOTP,
+    InputOTPGroup,
+    InputOTPSlot,
+} from '@/components/ui/input-otp';
+import { MailIcon } from 'lucide-react';
+import { REGEXP_ONLY_DIGITS } from 'input-otp';
 
 const VerificationStep = observer(() => {
     const { signUp: signUpStore } = useAuthFlowStores();
+
     return (
-        <Stack spacing={4}>
-            <Heading as="h1" size="lg" textAlign="center">
-                Verify Your Email
-            </Heading>
-            <FormControl isRequired>
-                <FormLabel>Verification Code</FormLabel>
-                <Input value={signUpStore.confirmCode} onChange={(e) => signUpStore.setField('confirmCode', e.target.value)} />
-            </FormControl>
+        <div className="flex flex-col items-center text-center">
+            <div className="mb-4 flex h-14 w-14 items-center justify-center rounded-2xl bg-brand-500/10">
+                <MailIcon className="size-7 text-brand-500" />
+            </div>
+
+            <h1 className="text-xl font-semibold tracking-tight text-foreground">
+                Check your inbox
+            </h1>
+            <p className="mt-2 max-w-[280px] text-sm text-muted-foreground">
+                We sent a 6-digit code to{' '}
+                <span className="font-medium text-foreground">
+                    {signUpStore.email || 'your email'}
+                </span>
+            </p>
+
+            <div className="mt-6 w-full">
+                <InputOTP
+                    maxLength={6}
+                    pattern={REGEXP_ONLY_DIGITS}
+                    value={signUpStore.confirmCode}
+                    onChange={(val) => signUpStore.setField('confirmCode', val)}
+                    containerClassName="justify-center"
+                    onComplete={() => signUpStore.confirmSignInCode()}
+                >
+                    <InputOTPGroup className="gap-2">
+                        {[0, 1, 2, 3, 4, 5].map((i) => (
+                            <InputOTPSlot
+                                key={i}
+                                index={i}
+                                className="h-12 w-11 rounded-lg border border-input text-base font-semibold first:rounded-l-lg last:rounded-r-lg"
+                            />
+                        ))}
+                    </InputOTPGroup>
+                </InputOTP>
+            </div>
+
             {signUpStore.confirmSignUpError && (
-                <InlineError message={signUpStore.confirmSignUpError} />
+                <div className="mt-4 w-full rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2.5 text-sm text-destructive">
+                    {signUpStore.confirmSignUpError}
+                </div>
             )}
-            <Button isLoading={signUpStore.confirmSignInLoading} onClick={() => signUpStore.confirmSignInCode()}>
-                Submit
+
+            <Button
+                className="mt-6 w-full"
+                disabled={
+                    signUpStore.confirmSignInLoading ||
+                    signUpStore.confirmCode.length < 6
+                }
+                onClick={() => signUpStore.confirmSignInCode()}
+            >
+                {signUpStore.confirmSignInLoading ? (
+                    <span className="flex items-center gap-2">
+                        <span className="size-4 animate-spin rounded-full border-2 border-primary-foreground/30 border-t-primary-foreground" />
+                        Verifying…
+                    </span>
+                ) : (
+                    'Verify email'
+                )}
             </Button>
-        </Stack>
+
+            <p className="mt-4 text-xs text-muted-foreground">
+                Didn&apos;t get a code? Check your spam folder.
+            </p>
+        </div>
     );
 });
 

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -2,8 +2,6 @@
 
 import React, { useEffect } from 'react';
 import { observer } from 'mobx-react-lite';
-import { Flex, Box, Button } from '@chakra-ui/react';
-import { ArrowBackIcon } from '@chakra-ui/icons';
 import { useAuthFlowStores } from '@/store/AuthFlowStoreContext';
 import UserDetailsStep from './components/UserDetailsStep';
 import VerificationStep from './components/VerificationStep';
@@ -11,12 +9,27 @@ import CreateOrganizationStep from './components/CreateOrganizationStep';
 import SuccessStep from './components/SuccessStep';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useRouter } from 'next/navigation';
+import { ArrowLeft, Check } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import Link from 'next/link';
 
+const STEPS = [
+    { id: 'userDetails', label: 'Account' },
+    { id: 'verification', label: 'Verify' },
+    { id: 'createOrganization', label: 'Workspace' },
+] as const;
+
+function getStepIndex(step: string): number {
+    const idx = STEPS.findIndex((s) => s.id === step);
+    return idx === -1 ? STEPS.length : idx;
+}
 
 const SignUpPage = observer(() => {
     const router = useRouter();
     const { signUp: signUpStore } = useAuthFlowStores();
-
+    const currentStepIndex = getStepIndex(signUpStore.step);
+    const isSuccess = signUpStore.step === 'success';
 
     useEffect(() => {
         return () => {
@@ -40,60 +53,122 @@ const SignUpPage = observer(() => {
     };
 
     return (
-        <Flex
-            align="center"
-            justify="center"
-            height="100vh"
-            bg="gray.50"
-            _dark={{ bg: 'gray.900' }}
-            overflow="hidden"
-        >
-            {/* Back Button */}
+        <div className="relative flex min-h-screen w-full items-center justify-center overflow-hidden bg-gradient-to-br from-slate-50 via-white to-purple-50/60 dark:from-gray-950 dark:via-gray-900 dark:to-purple-950/20">
+            {/* Decorative background blobs */}
+            <div className="pointer-events-none absolute inset-0 overflow-hidden">
+                <div className="absolute -top-48 -right-48 h-96 w-96 rounded-full bg-brand-500/8 blur-3xl dark:bg-brand-500/5" />
+                <div className="absolute -bottom-48 -left-48 h-96 w-96 rounded-full bg-brand-400/8 blur-3xl dark:bg-brand-400/5" />
+                <div className="absolute top-1/2 left-1/2 h-64 w-64 -translate-x-1/2 -translate-y-1/2 rounded-full bg-brand-500/4 blur-3xl" />
+            </div>
+
+            {/* Back button */}
             <Button
-                leftIcon={<ArrowBackIcon />}
-                variant="link"
-                position="absolute"
-                top="4"
-                left="4"
-                zIndex="10"
-                onClick={() => {
-                    router.back();
-                }}
+                variant="ghost"
+                size="sm"
+                className="absolute top-4 left-4 z-20 gap-1.5 text-muted-foreground hover:text-foreground"
+                onClick={() => router.back()}
             >
+                <ArrowLeft className="size-4" />
                 Back
             </Button>
 
-            <Box
-                width="full"
-                maxWidth="lg"
-                position="relative"
-                overflow="hidden"
-                height="100%"
-            >
-                <AnimatePresence mode="wait">
-                    <motion.div
-                        key={signUpStore.step}
-                        initial={{ x: '100%', opacity: 0 }}
-                        animate={{ x: 0, opacity: 1 }}
-                        exit={{ x: '-100%', opacity: 0 }}
-                        transition={{ duration: 0.25 }}
-                        style={{
-                            position: 'absolute',
-                            width: '100%',
-                            height: '100%',
-                            top: 0,
-                            left: 0,
-                            display: 'flex',
-                            flexDirection: 'column',
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                        }}
-                    >
-                        {getCurrentStepComponent()}
-                    </motion.div>
-                </AnimatePresence>
-            </Box>
-        </Flex>
+            {/* Main card */}
+            <div className="relative z-10 w-full max-w-md px-4 py-8">
+                {/* Logo / wordmark */}
+                <div className="mb-6 flex justify-center">
+                    <span className="text-xl font-bold tracking-tight text-foreground">
+                        Ajentify
+                    </span>
+                </div>
+
+                <div className="overflow-hidden rounded-2xl border border-gray-200/80 bg-white/90 shadow-xl shadow-brand-500/5 backdrop-blur-sm dark:border-gray-800/80 dark:bg-gray-900/90">
+                    {/* Step progress indicator */}
+                    {!isSuccess && (
+                        <div className="border-b border-gray-100 px-6 pt-5 pb-4 dark:border-gray-800">
+                            <div className="flex items-center">
+                                {STEPS.map((step, i) => {
+                                    const isCompleted = i < currentStepIndex;
+                                    const isActive = i === currentStepIndex;
+                                    return (
+                                        <React.Fragment key={step.id}>
+                                            <div className="flex flex-col items-center gap-1.5">
+                                                <div
+                                                    className={cn(
+                                                        'flex h-7 w-7 items-center justify-center rounded-full text-xs font-semibold transition-all duration-300',
+                                                        isCompleted &&
+                                                            'bg-brand-500 text-white',
+                                                        isActive &&
+                                                            'bg-brand-500 text-white ring-4 ring-brand-500/20',
+                                                        !isCompleted &&
+                                                            !isActive &&
+                                                            'bg-gray-100 text-gray-400 dark:bg-gray-800 dark:text-gray-500'
+                                                    )}
+                                                >
+                                                    {isCompleted ? (
+                                                        <Check className="size-3.5" strokeWidth={2.5} />
+                                                    ) : (
+                                                        i + 1
+                                                    )}
+                                                </div>
+                                                <span
+                                                    className={cn(
+                                                        'text-xs font-medium transition-colors',
+                                                        isActive || isCompleted
+                                                            ? 'text-brand-500'
+                                                            : 'text-muted-foreground'
+                                                    )}
+                                                >
+                                                    {step.label}
+                                                </span>
+                                            </div>
+                                            {i < STEPS.length - 1 && (
+                                                <div
+                                                    className={cn(
+                                                        'mb-5 h-px flex-1 mx-2 transition-all duration-300',
+                                                        i < currentStepIndex
+                                                            ? 'bg-brand-500'
+                                                            : 'bg-gray-200 dark:bg-gray-700'
+                                                    )}
+                                                />
+                                            )}
+                                        </React.Fragment>
+                                    );
+                                })}
+                            </div>
+                        </div>
+                    )}
+
+                    {/* Step content */}
+                    <div className="relative overflow-hidden">
+                        <AnimatePresence mode="wait">
+                            <motion.div
+                                key={signUpStore.step}
+                                initial={{ x: '60%', opacity: 0 }}
+                                animate={{ x: 0, opacity: 1 }}
+                                exit={{ x: '-60%', opacity: 0 }}
+                                transition={{ duration: 0.22, ease: [0.25, 0.46, 0.45, 0.94] }}
+                                style={{ padding: '1.5rem' }}
+                            >
+                                {getCurrentStepComponent()}
+                            </motion.div>
+                        </AnimatePresence>
+                    </div>
+                </div>
+
+                {/* Sign in link */}
+                {!isSuccess && (
+                    <p className="mt-4 text-center text-sm text-muted-foreground">
+                        Already have an account?{' '}
+                        <Link
+                            href="/signin"
+                            className="font-medium text-brand-500 hover:text-brand-400 hover:underline transition-colors"
+                        >
+                            Sign in
+                        </Link>
+                    </p>
+                )}
+            </div>
+        </div>
     );
 });
 

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,103 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Card({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<"div"> & { size?: "default" | "sm" }) {
+  return (
+    <div
+      data-slot="card"
+      data-size={size}
+      className={cn(
+        "group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "group/card-header @container/card-header grid auto-rows-min items-start gap-1 rounded-t-xl px-4 group-data-[size=sm]/card:px-3 has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-4 group-data-[size=sm]/card:[.border-b]:pb-3",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn(
+        "text-base leading-snug font-medium group-data-[size=sm]/card:text-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-4 group-data-[size=sm]/card:px-3", className)}
+      {...props}
+    />
+  )
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn(
+        "flex items-center rounded-b-xl border-t bg-muted/50 p-4 group-data-[size=sm]/card:p-3",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+}

--- a/src/components/ui/input-otp.tsx
+++ b/src/components/ui/input-otp.tsx
@@ -1,0 +1,87 @@
+"use client"
+
+import * as React from "react"
+import { OTPInput, OTPInputContext } from "input-otp"
+
+import { cn } from "@/lib/utils"
+import { MinusIcon } from "lucide-react"
+
+function InputOTP({
+  className,
+  containerClassName,
+  ...props
+}: React.ComponentProps<typeof OTPInput> & {
+  containerClassName?: string
+}) {
+  return (
+    <OTPInput
+      data-slot="input-otp"
+      containerClassName={cn(
+        "cn-input-otp flex items-center has-disabled:opacity-50",
+        containerClassName
+      )}
+      spellCheck={false}
+      className={cn("disabled:cursor-not-allowed", className)}
+      {...props}
+    />
+  )
+}
+
+function InputOTPGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="input-otp-group"
+      className={cn(
+        "flex items-center rounded-lg has-aria-invalid:border-destructive has-aria-invalid:ring-3 has-aria-invalid:ring-destructive/20 dark:has-aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function InputOTPSlot({
+  index,
+  className,
+  ...props
+}: React.ComponentProps<"div"> & {
+  index: number
+}) {
+  const inputOTPContext = React.useContext(OTPInputContext)
+  const { char, hasFakeCaret, isActive } = inputOTPContext?.slots[index] ?? {}
+
+  return (
+    <div
+      data-slot="input-otp-slot"
+      data-active={isActive}
+      className={cn(
+        "relative flex size-8 items-center justify-center border-y border-r border-input text-sm transition-all outline-none first:rounded-l-lg first:border-l last:rounded-r-lg aria-invalid:border-destructive data-[active=true]:z-10 data-[active=true]:border-ring data-[active=true]:ring-3 data-[active=true]:ring-ring/50 data-[active=true]:aria-invalid:border-destructive data-[active=true]:aria-invalid:ring-destructive/20 dark:bg-input/30 dark:data-[active=true]:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    >
+      {char}
+      {hasFakeCaret && (
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+          <div className="h-4 w-px animate-caret-blink bg-foreground duration-1000" />
+        </div>
+      )}
+    </div>
+  )
+}
+
+function InputOTPSeparator({ ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="input-otp-separator"
+      className="flex items-center [&_svg:not([class*='size-'])]:size-4"
+      role="separator"
+      {...props}
+    >
+      <MinusIcon
+      />
+    </div>
+  )
+}
+
+export { InputOTP, InputOTPGroup, InputOTPSlot, InputOTPSeparator }

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,20 @@
+import * as React from "react"
+import { Input as InputPrimitive } from "@base-ui/react/input"
+
+import { cn } from "@/lib/utils"
+
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+  return (
+    <InputPrimitive
+      type={type}
+      data-slot="input"
+      className={cn(
+        "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Input }

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,20 @@
+"use client"
+
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Label({ className, ...props }: React.ComponentProps<"label">) {
+  return (
+    <label
+      data-slot="label"
+      className={cn(
+        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Label }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Completely restyled the multi-step sign-up flow (`/signup`) to use shadcn components and Tailwind CSS, removing all Chakra UI dependencies from those files.

### New shadcn components added
- `Input` (`@base-ui/react`) — clean controlled text/email/password fields
- `Label` — accessible form labels with `data-slot` styling
- `Card` — used as a reference; card container is custom-styled for the glass effect
- `InputOTP` + `InputOTPGroup` + `InputOTPSlot` — for the verification code step

### Visual design

**Page chrome**
- Full-viewport gradient background (`slate-50 → white → purple-50`, dark variant included)
- Decorative blurred brand-colored orbs in the background corners
- Glassmorphism card: `bg-white/90 backdrop-blur-sm` with a soft brand shadow
- Ajentify wordmark above the card; "Already have an account? Sign in" link below

**Step progress indicator**
- Numbered circles (1 → 2 → 3) connected by horizontal lines in the card header
- Completed steps show a checkmark, active step gets a ring glow, future steps are muted
- Lines fill with brand purple as steps are completed
- Hidden on the success step

**Step-by-step changes**

| Step | What's new |
|------|-----------|
| Account (UserDetailsStep) | 2-column grid for first/last name; user icon; inline destructive error block |
| Verify (VerificationStep) | Large `InputOTP` with 6 individual slots; auto-submits when all 6 digits entered; "Check your spam" hint |
| Workspace (CreateOrganizationStep) | Building2 icon; helper text under the input |
| Success (SuccessStep) | Pulsing animated ring around a CheckCircle2 icon; "Get started" CTA with arrow |

**Animations** — Framer Motion `AnimatePresence` retained for the slide-in/out between steps, tuned to a slightly softer easing curve.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f09ad4ae-ea7c-4615-89b7-cf1ae7b26530"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f09ad4ae-ea7c-4615-89b7-cf1ae7b26530"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

